### PR TITLE
Do not require ultimate trust for server public key since it's defined by hand

### DIFF
--- a/app/models/crypto.js
+++ b/app/models/crypto.js
@@ -71,7 +71,7 @@ class Crypto {
         resolve: resolve,
         reject: reject
       };
-      Gpg.encrypt(msg, ['--armor','--recipient', recipient], function(error, buffer) {
+      Gpg.encrypt(msg, ['--armor','--recipient', recipient, '--yes', '--batch', '--trust-model', 'always'], function(error, buffer) {
         if (error != undefined) {
           return p.reject(error);
         }


### PR DESCRIPTION
Hello,

I was getting an error (prior to this change), while attempting to connect to the demo server

`app/config/config.json`:
```json
{
  "domain" : {
    "baseUrl": "https://demo.passbolt.com",
    "publicKey" : {
      "fingerprint" : "B805EAB6C90289E176AE08FB05918E8A1BE4C757"
    }
  },...
````


```sh
[travis@travis passbolt_cli]$ gpg --edit-key demo-server@passbolt.com
gpg (GnuPG) 2.0.22; Copyright (C) 2013 Free Software Foundation, Inc.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.


pub  2048R/0x05918E8A1BE4C757  created: 2016-03-02  expires: never       usage: SC  
                               trust: marginal      validity: unknown
sub  2048R/0x2353241FCCBEA5DF  created: 2016-03-02  expires: never       usage: E   
[ unknown] (1). demo server (Key for demo server) <demo-server@passbolt.com>
```
The passbolt key (associated with the above fingerprint, ignoring the sub key) is trusted, but I would still receive:

```sh
[travis@travis passbolt_cli]$ node passbolt.js auth -v
No authentication cookie found
GPGAuth login start with fingerprint D4997F5A3C29316A296FA4288CBDF6F9193D3504
GPGAuth Error during login
gpg: 0x2353241FCCBEA5DF: There is no assurance this key belongs to the named user
gpg: [stdin]: encryption failed: Unusable public key
```

This change - for the purpose of auth - accepts the key regardless of its trust.  A cursory googling showed I would need _ultimate_ trust to provide this "assurance" it's asking for, and I don't think that makes sense :).

I'm not actually advocating for this change, but just giving it as an example for someone more knowledgeable to figure out a better solution!

I'm thinking since the user is _manually entering_ the server's fingerprint into the configuration file, they're implicitly trusting it.