### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,15 @@ INNhsjl+27LCiCNmH8RNvPce
 ## Putting it all together
 
 Of course you can chain and pipe things up like:
+
 ```
-$ passbolt get $(passbolt find | grep inkscape | awk '{print $6}') > secret.gpg; gpg --decrypt secret.gpp
+$ passbolt get $(passbolt find  | awk '/inkscape/ { print $NF }') | gpg -q --no-tty 
 ```
 
+```
+-q and --no-tty 
+```
+are optional and ensures that only the password is printed.
 ## Runnning the tests
 
 ```


### PR DESCRIPTION
Use awk's pattern matching instead of using grep. Use the last field number NF instead of a fixed number, because if for example URI is empty one should use $5 and not $6 also see #18, which seems to try to solve the same problem