### PR TITLE
Read config from homedir if present

### DIFF
--- a/app/models/config.js
+++ b/app/models/config.js
@@ -11,6 +11,7 @@
  * @link          https://www.passbolt.com Passbolt(tm)
  */
 const fs = require('fs');
+const os = require('os');
 const _path = require('path');
 
 /**
@@ -23,14 +24,20 @@ class Config {
    * @returns {*}
    */
   static get(file, path) {
-    if (file === undefined) {
-      file = '/app/config/config.json';
-    }
     if (path === undefined) {
-      file = _path.dirname(require.main.filename) + file;
-    } else {
-      file = path + file;
+      path = _path.dirname(require.main.filename);
     }
+
+    if (file === undefined) {
+      const home = os.homedir();
+
+      if (fs.existsSync(home + '/.config/passbolt/config.json')) {
+        file = home + '/.config/passbolt/config.json';
+      } else {
+        file = path + '/app/config/config.json'
+      }
+    }
+
     if (!fs.existsSync(file)) {
       return Error(`Config file not found! [${file}]`);
     }


### PR DESCRIPTION
When passbolt_cli is installed global (for example with `npm install -g passbolt_cli`) it is harder to create a config file in the installation folder. This PR adds the possibility to use a config file in the current user's home directory.

To keep BC it checks first if the file exists and fallback to the old behavior if the file is not found.