### PR TITLE
fix: correctly get domain from CLI's arguments

### DIFF
--- a/app/controllers/serverKeyController.js
+++ b/app/controllers/serverKeyController.js
@@ -25,8 +25,10 @@ class ServerKeyController extends CliController {
       // config loading failed, still try to proceed
       // maybe program.domain is set and valid
     }
-    if (program.domain) {
-      this.domain = new Domain(program.domain);
+    
+    const options = program.opts();
+    if (options.domain) {
+      this.domain = new Domain(options.domain);
       if (program.skipCertificateValidation) {
         this._agentOptions = {rejectUnauthorized: false};
       }

--- a/app/controllers/serverKeyController.js
+++ b/app/controllers/serverKeyController.js
@@ -26,9 +26,9 @@ class ServerKeyController extends CliController {
       // maybe program.domain is set and valid
     }
     
-    const options = program.opts();
-    if (options.domain) {
-      this.domain = new Domain(options.domain);
+    const { domain } = program.opts();
+    if (domain) {
+      this.domain = new Domain(domain);
       if (program.skipCertificateValidation) {
         this._agentOptions = {rejectUnauthorized: false};
       }


### PR DESCRIPTION
Hello,

I installed the CLI on my machine to try some command and I find this issue : domain is not taken from argument for my command.

`passbolt server-key --domain=https://domain.com`

I just cloned the repo. Steps can be reproduced with

```bash
git clone git@github.com:passbolt/passbolt_cli.git
cd passbolt_cli
npm install
npm link
cd app/config
cp config.default.json config.json
cd ../..
```

I search the issue with commander and I found the solution [here](https://stackoverflow.com/a/66115965/8392395).
I made this fix and it now works :)

Additionnal data

```bash
node -v
v17.0.1
npm -v
8.1.0
nvm -v
0.37.2
```

Thank you for your work!
Have a nice day