### PR TITLE
Add JSON format option to find command

### DIFF
--- a/app/views/resources/index.js
+++ b/app/views/resources/index.js
@@ -43,9 +43,11 @@ class ResourceIndexView extends AppView {
     }
   }
 
-  render() {
+  render(format = null) {
     if (this.data.length === 0) {
       console.log('No resources to display. Create one first!');
+    } else if (format == 'json') {
+        console.log(JSON.stringify(this.data));
     } else {
       console.log(this.columnify(this.data, {
         minWidth: 20,

--- a/passbolt-find.js
+++ b/passbolt-find.js
@@ -25,6 +25,7 @@ const {list} = require('./app/lib/coercion');
     .option('-u, --fingerprint <fingerprint>', 'The user key fingerprint to authenticate with')
     .option('-p, --passphrase <passphrase>', 'The key passphrase')
     .option('--columns <items>', 'Coma separated columns to display', list)
+    .option('--json', 'Output resources in JSON format')
     .option('-v, --verbose', 'Display additional debug information')
     .parse(process.argv);
 
@@ -33,7 +34,7 @@ const {list} = require('./app/lib/coercion');
   try {
     let data = await resourceController.index();
     const view = new ResourceIndexView(data, program.opts().columns);
-    view.render();
+    view.render(program.opts().json ? 'json' : null);
   } catch (err) {
     resourceController.error(err);
   }


### PR DESCRIPTION
I'm build a dmenu utility to save passwords, usernames or uris to clipboard.

In order to get useful values from resources I need a more reliable way to extract resources information other then `awk` on columnify output.

This new `--json` option will allow any utility tool parse the output and process it as needed.