### PR TITLE
Add -o|--output option to find command

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,15 @@ free software foundation europe fsfe                 https://fsfe.org/index.en.h
 ftp                             user                 ftp://192.168.1.1                       2016-05-15 16:04:49  4a2f98e8-b326-3384-aa2b-c3c9a81be3f7
 ...
 ```
-Your can select the columns you want to display using the `--columns` arguments.
-Non existing collumns will be ignored.
 
+You can specify the output format by using the `-o` or `--output` argument and
+set it to either `columns` (default), `json` or `yaml`.
+```
+$ passbolt find --output json
+```
+
+You can select the columns you want to display using the `--columns` arguments.
+Non existing columns will be ignored.
 ```
 $ passbolt find --columns=name,uuid
 ```

--- a/app/views/resources/index.js
+++ b/app/views/resources/index.js
@@ -11,15 +11,22 @@
  * @link          https://www.passbolt.com Passbolt(tm)
  */
 const AppView = require('../appView.js');
+const yaml = require('js-yaml');
 
 /**
  * Resource Index View
  */
 class ResourceIndexView extends AppView {
-  constructor(data, columns) {
+  constructor(data, output, columns) {
     super();
     this.data = [];
+    this.defaultOutput = 'columns';
     this.defaultColumns = ['name', 'username', 'uri', 'modified', 'uuid'];
+    if (output == null) {
+      this.output = this.defaultOutput;
+    } else {
+      this.output = output;
+    }
     if (Array.isArray(columns) && columns.length) {
       this.columns = columns.filter(value => this.defaultColumns.includes(value));
     } else {
@@ -44,16 +51,28 @@ class ResourceIndexView extends AppView {
   }
 
   render() {
-    if (this.data.length === 0) {
-      console.log('No resources to display. Create one first!');
-    } else {
-      console.log(this.columnify(this.data, {
-        minWidth: 20,
-        columns: this.columns,
-        config: {
-          'username': {maxWidth: 64}
-        }
-      }));
+    if (this.output === 'json') {
+      console.log(JSON.stringify(this.data, null, 2));
+    }
+    else if (this.output === 'yaml') {
+      console.log(yaml.dump(this.data));
+    }
+    else if (this.output === 'columns') {
+      if (this.data.length === 0) {
+        console.log('No resources to display. Create one first!');
+      }
+      else {
+        console.log(this.columnify(this.data, {
+          minWidth: 20,
+          columns: this.columns,
+          config: {
+            'username': {maxWidth: 64}
+          }
+        }));
+      }
+    }
+    else {
+      console.log('Output format is unknown.');
     }
   }
 }

--- a/passbolt-find.js
+++ b/passbolt-find.js
@@ -24,6 +24,7 @@ const {list} = require('./app/lib/coercion');
     .usage('[options]', 'Search and list resources')
     .option('-u, --fingerprint <fingerprint>', 'The user key fingerprint to authenticate with')
     .option('-p, --passphrase <passphrase>', 'The key passphrase')
+    .option('-o, --output <output>', 'The output format. One of: (columns,json,yaml)')
     .option('--columns <items>', 'Coma separated columns to display', list)
     .option('-v, --verbose', 'Display additional debug information')
     .parse(process.argv);
@@ -32,7 +33,7 @@ const {list} = require('./app/lib/coercion');
   await resourceController.loginIfNeeded();
   try {
     let data = await resourceController.index();
-    const view = new ResourceIndexView(data, program.opts().columns);
+    const view = new ResourceIndexView(data, program.opts().output, program.opts().columns);
     view.render();
   } catch (err) {
     resourceController.error(err);


### PR DESCRIPTION
The output format option can be used to specify a different output format for the result. The default output format is `columns`. For better machine readability `json` and `yaml` have been added.